### PR TITLE
Replaced deprecated imread and imresize imports in the utils

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -5,3 +5,5 @@ numpy==1.12.1
 h5py==2.7.0
 statistics
 opencv-python==3.2.0
+imageio
+scikit-image

--- a/src/utils/preprocessor.py
+++ b/src/utils/preprocessor.py
@@ -1,5 +1,6 @@
 import numpy as np
-from scipy.misc import imread, imresize
+from imageio import imread
+from skimage.transform import resize as imresize
 
 
 def preprocess_input(x, v2=True):


### PR DESCRIPTION
There are few deprecated imports in scipy.misc in utils.preprocessor.py, replaced them with imread from imageio and resize from skimage.transform, and also updated the requirements file.